### PR TITLE
Single resize script; support multiple screengrabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@
 node_modules
 build
 _site
-chrome-out.png
-opera-out.png
+metadata/out-*.png
 EXTENSION_NAME-*.zip
 npm-debug.log
 test/test-code-in-harness-*.js

--- a/README.md
+++ b/README.md
@@ -73,10 +73,14 @@ Some further info on the test/build process:
 Changes
 -------
 
-### 0.0.2
+### 0.0.3 (2018-10-28)
+
+* Use the updated resize script from Landmarks, which is a single script for both Chrome and Opera, and supports resizing multiple screengrabs.
+
+### 0.0.2 (2018-10-21)
 
 * No need to check for DOMContentLoaded in options and GUI scripts, as they are included via `<script>` tags at the end of the `<body>`.
 
-### 0.0.1
+### 0.0.1 (2018-10-16)
 
 * Initial release.

--- a/metadata/resize-chrome
+++ b/metadata/resize-chrome
@@ -1,1 +1,0 @@
-convert -format png -trim +repage -background none -resize 1280x800 -gravity center -extent 1280x800 chrome.png chrome-out.png

--- a/metadata/resize-opera
+++ b/metadata/resize-opera
@@ -1,1 +1,0 @@
-convert -format png -trim +repage -background none -resize 612x408 -gravity center -extent 612x408 opera.png opera-out.png

--- a/metadata/resize.sh
+++ b/metadata/resize.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+chromeSize='1280x800'
+operaSize='612x408'
+
+function resize() {
+	browser=$1
+	size=$2
+	echo $browser $size...
+	for image in meta/$browser-*.png; do
+		echo $image...
+		base=`basename $image`
+		convert -format png -trim +repage -background none -resize $size -gravity center -extent $size $image meta/out-$base
+	done
+	echo
+}
+
+resize 'chrome' $chromeSize
+resize 'opera' $operaSize

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EXTENSION_NAME",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "EXTENSION_NAME",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "pre_build": "npm test",


### PR DESCRIPTION
This comes from https://github.com/matatk/landmarks/pull/209

Also adds dates to versions in the ChangeLog in the README.