### PR TITLE
Improve screengrab script

### DIFF
--- a/metadata/resize.sh
+++ b/metadata/resize.sh
@@ -1,18 +1,21 @@
 #!/bin/sh
-chromeSize='1280x800'
+chromeSize='640x400'
 operaSize='612x408'
+chromeBackgroundColour='rgb(250,250,250)'
+operaBackgroundColor='rgb(237,237,237)'
 
 function resize() {
 	browser=$1
 	size=$2
-	echo $browser $size...
+	background=$3
+	echo $browser $size $background...
 	for image in meta/$browser-*.png; do
 		echo $image...
 		base=`basename $image`
-		convert -format png -trim +repage -background none -resize $size -gravity center -extent $size $image meta/out-$base
+		convert -format png +repage -background $background -transparent orange -resize $size -gravity center -extent $size $image meta/out-$base
 	done
 	echo
 }
 
-resize 'chrome' $chromeSize
-resize 'opera' $operaSize
+resize 'chrome' $chromeSize $chromeBackgroundColour
+resize 'opera' $operaSize $operaBackgroundColor


### PR DESCRIPTION
[ Copied from Landmarks. ]

* Downscale the Chrome images to 640x400 per
https://developer.chrome.com/webstore/images?hl=en-GB#screenshots
using ImageMagick; hopefully this will result in improved text quality
(generally it looks better).
* Use a background colour for the images that matches the current page
design for Chrome Web Store and Opera add-ons.

Note: Firefox actually asked for smaller images too, but seems to cope
fine with full-size ones.